### PR TITLE
fix: updated publish commands for binary size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,4 @@ nunit-*.xml
 /.vs/premake-manager-cli/FileContentIndex
 /.premake/Premake 5.0-beta6/windows
 /.vs/**
+settings.json

--- a/premake5.lua
+++ b/premake5.lua
@@ -26,7 +26,9 @@ architecture "x64"
       vsprops {
          PublishSingleFile = "true",
          SelfContained = "true",
-         IncludeNativeLibrariesForSelfExtract = "true"
+         IncludeNativeLibrariesForSelfExtract = "true",
+         PublishTrimmed =  "true",
+         Nullable = "enable"
       }
       filter "configurations:Debug"
          defines { "DEBUG" }
@@ -36,3 +38,4 @@ architecture "x64"
          symbols "Off"
          defines { "NDEBUG" }
          optimize "On"
+         

--- a/publish.bat
+++ b/publish.bat
@@ -1,5 +1,5 @@
-dotnet publish -r win-x64 -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true
-dotnet publish -r linux-x64 -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true
-dotnet publish -r osx-arm64 -p:PlatformTarget=arm64 -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true
+dotnet publish -r win-x64 -c Release -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=true -p:PublishReadyToRun=false -p:DebugType=None -p:DebugSymbols=false -p:TrimMode=partial -p:InvariantGlobalization=true -p:EnableCompressionInSingleFile=true
+dotnet publish -r linux-x64 -c Release -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=true -p:PublishReadyToRun=false -p:DebugType=None -p:DebugSymbols=false -p:TrimMode=partial -p:InvariantGlobalization=true -p:EnableCompressionInSingleFile=true
+dotnet publish -r osx-arm64 -c Release -p:PlatformTarget=arm64 -p:PublishSingleFile=true --self-contained true -p:IncludeNativeLibrariesForSelfExtract=true -p:PublishTrimmed=true -p:PublishReadyToRun=false -p:DebugType=None -p:DebugSymbols=false -p:TrimMode=partial -p:InvariantGlobalization=true -p:EnableCompressionInSingleFile=true
 
 pause


### PR DESCRIPTION
this PR optimises the excutable size to 15mb from 75 mb. *5 improvement